### PR TITLE
alreadyinstalled couldn't fire due to thisness

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -262,11 +262,11 @@ var daemon = function(config){
 
         if (this.exists){
           var missing = false;
-          if (!fs.existsSync(path.join(me.root,this._exe))){
+          if (!fs.existsSync(path.join(this.root,this._exe))){
             this.log.warn('The main executable is missing or cannot be found ('+path.join(me.root,this._exe)+')');
             missing = true;
           }
-          if (!fs.existsSync(path.join(me.root,this.id+'.xml'))){
+          if (!fs.existsSync(path.join(this.root,this.id+'.xml'))){
             this.log.warn('The primary configuration file is missing or cannot be found ('+path.join(me.root,this.id+'.xml')+')');
             missing = true;
           }


### PR DESCRIPTION
changed `me` (defined too late) to `this`

```
C:\Program Files (x86)\WebAppCenter\node_modules\node-windows\lib\daemon.js:264
          if (!fs.existsSync(path.join(me.root,this._exe))){
                                         ^
TypeError: Cannot read property 'root' of undefined
    at Object.defineProperties.install.value [as install] (C:\Program Files (x86)\WebAppCenter\node_modules\node-windows
\lib\daemon.js:264:42)
    at Object.<anonymous> (C:\Program Files (x86)\WebAppCenter\bin\install-win-service.js:45:5)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
PS C:\Program Files (x86)\WebAppCenter> node .\bin\install-win-service.js
C:\Program Files (x86)\WebAppCenter\bin
alreadyinstalled
PS C:\Program Files (x86)\WebAppCenter>
```
