### PR TITLE
Fix for using me.root instead of this.root

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -364,11 +364,11 @@ var daemon = function(config){
         if (this.exists){
           var missing = false;
           if (!fs.existsSync(path.join(this.root,this._exe))){
-            this.log.warn('The main executable is missing or cannot be found ('+path.join(me.root,this._exe)+')');
+            this.log.warn('The main executable is missing or cannot be found ('+path.join(this.root,this._exe)+')');
             missing = true;
           }
           if (!fs.existsSync(path.join(this.root,this.id+'.xml'))){
-            this.log.warn('The primary configuration file is missing or cannot be found ('+path.join(me.root,this.id+'.xml')+')');
+            this.log.warn('The primary configuration file is missing or cannot be found ('+path.join(this.root,this.id+'.xml')+')');
             missing = true;
           }
           if (missing.length > 0){


### PR DESCRIPTION
Fix for using me.root instead of this.root in the log message, this caused an exception and so caused the install to look like it went wrong.
