### PR TITLE
Removed os from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
   "author": "Corey Butler <corey@coreybutler.com>",
   "devDependencies": {},
   "main": "lib/node-windows.js",
-  "os": [
-    "win32"
-  ],
   "preferGlobal": true,
   "dependencies": {
     "optimist": "~0.6.0"


### PR DESCRIPTION
Required in order to use this package in a platform independent package (with node-linux and node-mac).
