### PR TITLE
Fix process restart bug

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -68,8 +68,8 @@ var server = require('net').createServer().listen();
  * @method monitor
  * Monitor the process to make sure it is running
  */
-var monitor = function(){
-  if(!child.pid){
+var monitor = function(exit){
+  if(!child.pid || exit){
 
     // If the number of periodic starts exceeds the max, kill the process
     if (starts >= argv.r){
@@ -133,7 +133,7 @@ var launch = function(){
     }
 
     // Monitor the process
-    monitor();
+    monitor(true);
   });
 };
 


### PR DESCRIPTION
The child.pid still exists after the child exit event is executed so we need another way to tell monitor that child was kill.

I found this problem using node 0.10.25 on Windows XP and Windows Server 2003.

I think this is going a problem here too: https://github.com/coreybutler/daemon-manager/blob/master/lib/controller.js#L42
