### PR TITLE
Allow to use wait and grow with 0 as integer

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -163,7 +163,7 @@ var daemon = function(config){
       enumerable: true,
       writable: false,
       configurable: false,
-      value: config.wait || 1
+      value: !isNaN(config.wait) ? config.wait : 1
     },
 
     /**
@@ -177,7 +177,7 @@ var daemon = function(config){
       enumerable: true,
       writable: false,
       configurable: false,
-      value: config.grow || .25
+      value: !isNaN(config.grow) ? config.grow : .25
     },
 
     _directory: {


### PR DESCRIPTION
This patch fix a problem with {wait: 0, grow: 0}, it was changing the values to the default ones. This fix prevent this behavior.

*For a temporary fix, set the values as string: {wait: '0', grow: '0'}
