### PR TITLE
Update daemon.js to allow passing of flags

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -104,6 +104,7 @@ var daemon = function(config){
           script: '"'+wrapper+'" -f "'+this.script+'" -l "'+this.name+'" -g '+this.grow
                   +' -w '+this.wait+(this.maxRetries!==null?' -m '+this.maxRetries:'')
                   +' -r '+this.maxRestarts+' -a '+(this.abortOnError==true?'y':'n'),
+          flags:(typeof config.flags == "string" ? config.flags + " --harmony" : null),
           description: this.description,
           logpath: this.logpath,
           env: config.env


### PR DESCRIPTION
There does not seem to be a way to pass flags to the underlying node.exe call, even though there is this facility in the arguments tag in the XML file. This small hack allows flags to be passed on.