### PR TITLE
execPath parameter to allow different executable

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -339,7 +339,7 @@ var daemon = function(config){
       enumerable: true,
       writable: true,
       configurable: false,
-      value: config.execPath !== undefined ? require('path').resolve(config.execPath) : process.execPath
+      value: config.execPath !== undefined ? require('path').resolve(config.execPath) : null
     },
 
     /**

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -107,7 +107,8 @@ var daemon = function(config){
           description: this.description,
           logpath: this.logpath,
           env: config.env,
-          flags: config.flags
+          flags: config.flags,
+          execPath: this.execPath
         });
       }
     },
@@ -327,6 +328,18 @@ var daemon = function(config){
       writable: true,
       configurable: false,
       value: config.script !== undefined ? require('path').resolve(config.script) : null
+    },
+
+    /**
+     * @cfg {String} execPath
+     * The absolute path to the executable that will launch the script.
+     * If omitted process.execPath is used.
+     */
+    execPath: {
+      enumerable: true,
+      writable: true,
+      configurable: false,
+      value: config.execPath !== undefined ? require('path').resolve(config.execPath) : process.execPath
     },
 
     /**

--- a/lib/winsw.js
+++ b/lib/winsw.js
@@ -27,6 +27,7 @@ module.exports = {
     config.description = config.description || '';
     config.flags = config.flags || '--harmony';
     config.logmode = 'rotate';
+    config.execPath = config.execPath || process.execPath;
 
     // Initial template
     var xml = '<service><id>'
@@ -35,7 +36,7 @@ module.exports = {
             +config.name
             +'</name><description>'
             +config.description
-            +'</description><executable>' + process.execPath + '</executable><arguments>'
+            +'</description><executable>' + config.execPath + '</executable><arguments>'
             +config.flags
             +' '+config.script
             +'</arguments><logmode>'


### PR DESCRIPTION
Added execPath parameter that can be passed when creating a service. It allows to change the executable that will run the service (different node, or specify node when installing a service from an atom-shell app). If omitted process.execPath is used