### PR TITLE
Fix services with accented letters

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -412,7 +412,7 @@ var daemon = function(config){
      * @method uninstall
      * Uninstall the service.
      * @param {Number} [waitTime]
-     * Seconds to wait until winsw.exe finish processing the uninstall command.     
+     * Seconds to wait until winsw.exe finish processing the uninstall command.
      *
      *      var Service = require('node-windows').Service;
      *
@@ -521,7 +521,7 @@ var daemon = function(config){
           throw Error('The service "'+this.name+'" does not exist or could not be found.');
         }
 
-        this.execute('NET START "'+me.name+'"',function(err,stdout,stderr){
+        this.execute('NET START "'+me._exe+'"',function(err,stdout,stderr){
           if (err){
             if (err.code == 2){
               if (err.message.indexOf('already been started') >= 0 && err.message.indexOf('service name is invalid') < 0){
@@ -558,7 +558,7 @@ var daemon = function(config){
       value: function(){
         var me = this;
 
-        me.execute('NET STOP "'+me.name+'"',function(err,stdout,stderr){
+        me.execute('NET STOP "'+me._exe+'"',function(err,stdout,stderr){
           if (err){
             if (err.code == 2){
               me.log.warn('An attempt to stop the service failed because the service is/was not running.');


### PR DESCRIPTION
If your service has accented letters, it's not possible to start or stop it, using the service id is more reliable than service name and corrects this bug.