### PR TITLE
Support for .NET 4.0

### DIFF
--- a/bin/winsw/winsw.exe.config
+++ b/bin/winsw/winsw.exe.config
@@ -1,0 +1,17 @@
+<!--
+See
+  https://github.com/kohsuke/winsw/issues/103
+  https://github.com/kohsuke/winsw#net-runtime-40
+  http://www.davidmoore.info/blog/2010/12/17/running-net-2-runtime-applications-under-the-net-4-runtime/
+-->
+<configuration>
+  <startup> <!-- useLegacyV2RuntimeActivationPolicy="true" -->
+    <supportedRuntime version="v2.0.50727" />
+    <supportedRuntime version="v4.0" />
+  </startup>
+  <!--
+  <runtime>
+    <NetFx40_LegacySecurityPolicy enabled="true"/>
+  </runtime>
+  -->
+</configuration>

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -487,6 +487,7 @@ var daemon = function(config){
 
               // Remove the executable
               rm(me.id+'.exe');
+              rm(me.id+'.exe.config');
 
               // Remove all other files
               var _files = fs.readdirSync(me.root);

--- a/lib/winsw.js
+++ b/lib/winsw.js
@@ -71,7 +71,7 @@ module.exports = {
 
   /**
    * @method createExe
-   * Create the executable
+   * Create the executable & executable config file
    * @param {String} name
    * The alphanumeric string (spaces are stripped) of the `.exe` file. For example, `My App` generates `myapp.exe`
    * @param {String} [dir=cwd]
@@ -89,11 +89,18 @@ module.exports = {
 
     dir = dir || process.cwd();
 
-    var origin = p.join(__dirname,'..','bin','winsw','x'+(require('os').arch().indexOf('64')>0 ? '64':'86'),'winsw.exe'),
-        dest = p.join(dir,name.replace(/[^\w]/gi,'').toLowerCase()+'.exe'),
-        data = fs.readFileSync(origin,{encoding:'binary'});
+    var srcdir = p.join(__dirname,'..','bin','winsw'),
+        origin = p.join(srcdir,'x'+(require('os').arch().indexOf('64')>0 ? '64':'86'),'winsw.exe'),
+        configorigin = p.join(srcdir,'winsw.exe.config'),
+        destbase = name.replace(/[^\w]/gi,'').toLowerCase(),
+        dest = p.join(dir, destbase + '.exe'),
+        configdest = p.join(dir, destbase + '.exe.config')
+        data = fs.readFileSync(origin,{encoding:'binary'}),
+        configdata = fs.readFileSync(configorigin);
 
     fs.writeFileSync(dest,data,{encoding:'binary'});
+    fs.writeFileSync(configdest,configdata);
+
     callback && callback();
     //require('child_process').exec('Icacls "'+dest+'" /grant Everyone:(F)',callback)
     //require('child_process').exec('copy "'+origin+'" /y /v /b "'+dest+'" /b',callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-windows",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Support for Windows services, event logging, UAC, and several helper methods for interacting with the OS.",
   "keywords": [
     "ngn",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-windows",
-  "version": "0.1.11",
+  "version": "0.1.11-PR107",
   "description": "Support for Windows services, event logging, UAC, and several helper methods for interacting with the OS.",
   "keywords": [
     "ngn",


### PR DESCRIPTION
winsw.exe targets .NET 2.0.  Recent Windows distros (like 8.1) don't include .NET 3.5 or earlier.  This allows the current winsw.exe to run against both .NET 2.0 & 4.0.  See:
- https://github.com/kohsuke/winsw/issues/103
- https://github.com/kohsuke/winsw#net-runtime-40
- http://www.davidmoore.info/blog/2010/12/17/running-net-2-runtime-applications-under-the-net-4-runtime/

This change adds a `.exe.config` file to the service executable, allowing it to run unchanged against .NET 4.0.
