### PR TITLE
fixed logic in case specified directory doesn't exist

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -64,8 +64,8 @@ var Logger = require('./eventlog'),
 if (argv.d){
   if (!require('fs').existsSync(p.resolve(argv.d))){
     console.warn(argv.d+' not found.');
+    argv.d = process.cwd();
   }
-  argv.d = process.cwd();
 }
 
 if (typeof argv.m === 'string'){


### PR DESCRIPTION
It looks like the fix @coreybutler provided to make `cwd` optional had one teeny, tiny error which caused the `cwd` to be ignored in all cases, defeating the purpose of specifying `cwd`.  This is a one-liner fix.