### PR TITLE
Allowing the user the use \n while outputting event logs

### DIFF
--- a/lib/eventlog.js
+++ b/lib/eventlog.js
@@ -58,12 +58,14 @@ var write = function(log,src,type,msg,id,callback){
   id = typeof id == 'number' ? (id > 0 ? id : 1000) : 1000;
   src = (src || 'Unknown Application').trim();
 
-  if (/(\n)/.test(msg))
-  {
+  if (/(\n)/.test(msg)){
+
+    var path = require('path');
+    var fs = require('fs');
     var escapedMsg = msg.replace(/(\n)+/g, '!LF!');
-    var fs = require("fs");
     var batContents = "setlocal enableDelayedExpansion\nset LF=^\n\n\n" + "eventcreate /L " + log + " /T " + type + " /SO \"" + src + "\" /D \"" + escapedMsg + "\" /ID " + id;
-    fs.writeFile('event.bat', batContents, (err) => {
+
+    fs.writeFile(path.resolve(__dirname, '..', "bin", 'event.bat'), batContents, (err) => {
       try
       {
         if (err) throw err;
@@ -75,8 +77,7 @@ var write = function(log,src,type,msg,id,callback){
       wincmd.elevate("event.bat");
     });
   }
-  else
-  {
+  else{
     wincmd.elevate("eventcreate /L "+log+" /T "+type+" /SO \""+src+"\" /D \""+msg+"\" /ID "+id,callback);
   }
 };

--- a/lib/eventlog.js
+++ b/lib/eventlog.js
@@ -74,7 +74,7 @@ var write = function(log,src,type,msg,id,callback){
       {
         console.error ("Error occured: " + err);
       }
-      wincmd.elevate("event.bat");
+      wincmd.elevate(path.resolve(__dirname, '..', "bin", 'event.bat'));
     });
   }
   else{

--- a/lib/eventlog.js
+++ b/lib/eventlog.js
@@ -64,7 +64,14 @@ var write = function(log,src,type,msg,id,callback){
     var fs = require("fs");
     var batContents = "setlocal enableDelayedExpansion\nset LF=^\n\n\n" + "eventcreate /L " + log + " /T " + type + " /SO \"" + src + "\" /D \"" + escapedMsg + "\" /ID " + id;
     fs.writeFile('event.bat', batContents, (err) => {
-      if (err) throw err;
+      try
+      {
+        if (err) throw err;
+      }
+      catch (err)
+      {
+        console.error ("Error occured: " + err);
+      }
       wincmd.elevate("event.bat");
     });
   }

--- a/lib/eventlog.js
+++ b/lib/eventlog.js
@@ -58,7 +58,20 @@ var write = function(log,src,type,msg,id,callback){
   id = typeof id == 'number' ? (id > 0 ? id : 1000) : 1000;
   src = (src || 'Unknown Application').trim();
 
-  wincmd.elevate("eventcreate /L "+log+" /T "+type+" /SO \""+src+"\" /D \""+msg+"\" /ID "+id,callback);
+  if (/(\n)/.test(msg))
+  {
+    var escapedMsg = msg.replace(/(\n)+/g, '!LF!');
+    var fs = require("fs");
+    var batContents = "setlocal enableDelayedExpansion\nset LF=^\n\n\n" + "eventcreate /L " + log + " /T " + type + " /SO \"" + src + "\" /D \"" + escapedMsg + "\" /ID " + id;
+    fs.writeFile('event.bat', batContents, (err) => {
+      if (err) throw err;
+      wincmd.elevate("event.bat");
+    });
+  }
+  else
+  {
+    wincmd.elevate("eventcreate /L "+log+" /T "+type+" /SO \""+src+"\" /D \""+msg+"\" /ID "+id,callback);
+  }
 };
 
 // Basic functionality


### PR DESCRIPTION
This little piece of code allows the user to use line breaks using 
`log.* ("messageline1 \nMessage line 2");` 
Previously if one was using this, the event wouldn't  get logged at all.
