### PR TITLE
bugfix(security) dummy server opens port to world

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -77,7 +77,7 @@ if (typeof argv.m === 'string'){
 argv.f = p.resolve(argv.f);
 
 // Hack to force the wrapper process to stay open by launching a ghost socket server
-var server = require('net').createServer().listen();
+var server = require('net').createServer().listen(0, '127.0.0.1');
 
 /**
  * @method monitor


### PR DESCRIPTION
@coreybutler this fixes a security issue opened here:
https://github.com/coreybutler/node-windows/issues/144

Without this fix the dummy server exposes a port which can be attacked using NC to kill the remote process. This forces the server to at least listen on localhost only. The 0 parameter will force a random port is selected as previously.
