### PR TITLE
fix over-removing files during uninstall

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -494,17 +494,26 @@ var daemon = function(config){
               rm(me.id+'.exe');
 
               // Remove all other files
-              var _files = fs.readdirSync(me.root);
-              _files.forEach(function(f){
-                rm(f);
+              var _other_files = fs.readdirSync(me.root).filter(file => {
+                const regex = /^.+\.((wrapper|out|err)\.log)|(exe|xml)$/g
+                return !regex.exec(file)
+              })
+              _other_files.forEach(function(f){
+                rm(f)
               });
 
-              if (me.root !== path.dirname(me.script)){
-                fs.rmdir(me.root,function(){
-                  sleep(1);
+              // Remove the dir iff it's empty
+              if (fs.readdirSync(me.root).length === 0) {
+                if (me.root !== path.dirname(me.script)){
+                  fs.rmdir(me.root,function(){
+                    sleep(1);
+                    me.emit('uninstall');
+                  });
+                } else {
                   me.emit('uninstall');
-                });
-              } else {
+                }
+              }
+              else {
                 me.emit('uninstall');
               }
             }

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -494,7 +494,7 @@ var daemon = function(config){
               rm(me.id+'.exe');
 
               // Remove all other files
-              var _other_files = fs.readdirSync(me.root).filter(file => {
+              var _other_files = fs.readdirSync(me.root).filter(function (file) {
                 const regex = /^.+\.((wrapper|out|err)\.log)|(exe|xml)$/g
                 return !regex.exec(file)
               })


### PR DESCRIPTION
From issue #117, **uninstall** function will remove the whole "daemon" directory regardless of what's inside the directory. This could lead to the problem when there are more than one services in the same daemon directory redering another serivce could not be "uninstalled". 

I fixed (and tested) by defining `_other_files` that will match only really "other files" and will be removed just that. If there are remaining files, the daemon directory will not be deleted (that indicates there are some other services files lingering inside)

ps. this is my first pull-request, suggestions are welcome.