### PR TITLE
Fixed EventLogger premissions

### DIFF
--- a/lib/eventlog.js
+++ b/lib/eventlog.js
@@ -42,11 +42,13 @@
  *     });
  */
 var wincmd = require('./binaries'),
+    exec = require("child_process").exec,
     eventlogs = ['APPLICATION','SYSTEM'],
     validtypes = ['ERROR','WARNING','INFORMATION','SUCCESSAUDIT','FAILUREAUDIT'];
 
 // Write a message to the log. This will create the log if it doesn't exist.
 var write = function(log,src,type,msg,id,callback){
+  var cmd;
 
   if (msg == null) {return};
   if (msg.trim().length == 0) {return};
@@ -58,7 +60,15 @@ var write = function(log,src,type,msg,id,callback){
   id = typeof id == 'number' ? (id > 0 ? id : 1000) : 1000;
   src = (src || 'Unknown Application').trim();
 
-  wincmd.elevate("eventcreate /L "+log+" /T "+type+" /SO \""+src+"\" /D \""+msg+"\" /ID "+id,callback);
+  cmd = "eventcreate /L "+log+" /T "+type+" /SO \""+src+"\" /D \""+msg+"\" /ID "+id;
+
+  exec(cmd, function(err) {
+    if (err && err.message.indexOf("Access is Denied")) {
+      wincmd.elevate(cmd, callback);
+    } else if (callback){
+      callback(err);
+    }
+  });
 };
 
 // Basic functionality


### PR DESCRIPTION
Made a small modification to the EventLogger so that it doesn't need to request permission each time it logs a message. Running `eventcreate` with elevated privileges once will create a event source using the source it was called with. From then on any calls to `eventcreate` that use the same source will not require elevated privileges. Now `elevate.cmd` will only be called when permissions are required.

regedt32 is a great tool for monitoring the Event Logger's permissions. To see which applications have permission to log to the Event Logger go to `HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Eventlog\Application` 