### PR TITLE
Allow LogOn As A Service to be set Automatically if using logOnAs

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -399,6 +399,7 @@ var daemon = function(config){
         account: null,
         password: null,
         domain: process.env.COMPUTERNAME,
+        allowServiceLogon: true,
         mungeCredentialsAfterInstall: true
       }
     },

--- a/lib/winsw.js
+++ b/lib/winsw.js
@@ -127,7 +127,8 @@ module.exports = {
         serviceaccount: [
           {domain: config.logOnAs.domain},
           {user: config.logOnAs.account},
-          {password: config.logOnAs.password}
+          {password: config.logOnAs.password},
+          {allowservicelogon: config.logOnAs.allowServiceLogon}
         ]
       });
     }


### PR DESCRIPTION
When installing a service using `svc.logOnAs` it will fail to start the first time after install because the account doesn't have 'LogOn As A Service' set