### PR TITLE
Add listener for SIGKILL

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -187,6 +187,7 @@ var killkid = function(){
 process.on('exit', killkid);
 process.on("SIGINT", killkid);
 process.on("SIGTERM", killkid);
+process.on("SIGKILL", killkid);
 
 // Launch the process
 launch('info', 'Starting ' + argv.f);


### PR DESCRIPTION
Issue - 
When running `taskkill` or similar term, wrapper.js doesn't send shutdown message to child process.

Listen to `SIGKILL` in order to kill child process in wrapper.js