### PR TITLE
feat: allow empty password in logOnAs

### DIFF
--- a/lib/winsw.js
+++ b/lib/winsw.js
@@ -120,14 +120,12 @@ module.exports = {
     }
 
     // optionally set the service logon credentials
-    if (config.logOnAs && config.logOnAs.account && config.logOnAs.password &&
-      config.logOnAs.domain)
-    {
+    if (config.logOnAs) {
       xml.push({
         serviceaccount: [
-          {domain: config.logOnAs.domain},
-          {user: config.logOnAs.account},
-          {password: config.logOnAs.password}
+          {domain: config.logOnAs.domain || 'NT AUTHORITY'},
+          {user: config.logOnAs.account || 'LocalSystem'},
+          {password: config.logOnAs.password || ''}
         ]
       });
     }


### PR DESCRIPTION
If you try to use an empty password in `logOnAs` (e.g: with `Local Service`) node-windows does not create a `serviceaccount` entry because password is falsy. This change defaults any missing credentials to the winsw default (NT AUTHORITY\LocalSystem).

It may be better to express this like `if any of [domain,account,password] missing in logOnAs use the default credentials object` so no one is surprised by a default in isolation.