### PR TITLE
Fix - Replace \r and \n with the accepted return line character

### DIFF
--- a/lib/eventlog.js
+++ b/lib/eventlog.js
@@ -52,6 +52,8 @@ var write = function(log,src,type,msg,id,callback){
 
   if (msg == null) {return};
   if (msg.trim().length == 0) {return};
+  
+  msg = msg.replace(/\r\n|\n\r|\r|\n/g, "\f")
 
   log = log || 'APPLICATION';
   log = eventlogs.indexOf(log.toUpperCase()) >= 0 ? log : 'APPLICATION';


### PR DESCRIPTION
A simple 1 line fix to allow for `\r`, `\n`, `\r\n`, and `\n\r` all to be converted into `\f`, the accepted Return Line character for the Event Viewer.

As said in the Issue I asked about for this, #240, This will result in the XML data to be malformed for some reason. So with this, you won't be able to view extended details or the raw XML. However, considering the only actual implementation I see for this, is just sending a message, I personally don't see a problem with this. If you believe this could be a potential issue, I can go back through and make it an optional feature? 