### PR TITLE
Added missing XML field for logOnAs

### DIFF
--- a/lib/winsw.js
+++ b/lib/winsw.js
@@ -125,7 +125,8 @@ module.exports = {
         serviceaccount: [
           {domain: config.logOnAs.domain || 'NT AUTHORITY'},
           {user: config.logOnAs.account || 'LocalSystem'},
-          {password: config.logOnAs.password || ''}
+          {password: config.logOnAs.password || ''},
+          {allowservicelogon: 'true'}
         ]
       });
     }


### PR DESCRIPTION
Added the line:
{allowservicelogon: 'true'}

to the winsw.js for the logOnAs. Without that parameter, the service is being installed, but doesn't start automatically and requires manual password setting in the service manager as it won't start due to "log failed" issue.
After the mentioned line is added into the config XML file, the service will start automatically as another user without issues.