### PR TITLE
Replace optimist with yargs

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,15 +1,15 @@
 // Handle input parameters
 var Logger = require('./eventlog'),
-    optimist = require('optimist'),
+    yargs = require('yargs'),
     net = require('net'),
     max = 60,
     p = require('path'),
-    argv = optimist
+    argv = yargs
       .demand('file')
       .alias('f','file')
       .describe('file','The absolute path of the script to be run as a process.')
       .check(function(argv){
-        require('fs').existsSync(p.resolve(argv.f),function(exists){
+        return require('fs').existsSync(p.resolve(argv.f),function(exists){
           return exists;
         });
       })

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "preferGlobal": true,
   "dependencies": {
-    "optimist": "~0.6.0",
+    "yargs": "^15.4.0",
     "xml": "0.0.12"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
optimist is deprecated and depends on an [insecure version of a minimist](https://www.npmjs.com/advisories/1179).