### PR TITLE
Prevent security scanner from killing wrapper with ECONNRESET

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -85,11 +85,19 @@ if (typeof argv.m === 'string'){
 argv.f = p.resolve(argv.f);
 
 // Hack to force the wrapper process to stay open by launching a ghost socket server
-var server = net.createServer().listen();
+// Some security penetration tests create numerous daily socket errors that restart the wrapper.
+// Handling errors here is preferable to restarting the service for no real reason.
+var server = net.createServer((c) => {
+  c.on('error', (err) => {
+    log.warn(`Socket error (${err.code}) in wrapper keep-alive. Ignoring...`);
+  });
+});
+server.listen();
 
 server.on('error', function (err) {
-    launch('warn', err.message);
-    server = net.createServer().listen();
+  server.close(); // don't leak a trail of unclosed servers
+  launch('warn', err.message);
+  server = net.createServer().listen();
 });
 
 /**


### PR DESCRIPTION
wrapper.js is continually killed by a security penetration test that causes ECONNRESET errors on the socket. Handling the socket error prevents a server error which forestalls cycling the app. Since we don't care about the connections anyway, I log the error but ignore it.

In server,on('error'), I added a server.close() because server errors do not automatically close the server, so it was probably leaking servers.