### PR TITLE
Feature/install dir

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -255,7 +255,7 @@ var daemon = function(config){
       enumerable: false,
       writable: true,
       configurable: false,
-      value: config.script !== null ? path.dirname(config.script) : null
+      value: config.installDir ? path.dirname(config.installDir) : config.script !== null ? config.script : null
     },
 
     /**
@@ -265,12 +265,9 @@ var daemon = function(config){
       enumerable: false,
       writable: false,
       configurable: false,
-      value: function(dir){
+      value: function(){
         if (this.script == null || this.name == null){
           throw Error('Script and Name are required but were not provided.');
-        }
-        if (dir){
-          this._directory = path.resolve(dir);
         }
         return path.resolve(path.join(this._directory,daemonDir));
       }
@@ -493,7 +490,7 @@ var daemon = function(config){
       enumerable: true,
       writable: false,
       configurable: false,
-      value: function(dir){
+      value: function(){
         if (this.script == null || this.name == null){
           throw Error('Script and Name are required but were not provided.');
         }
@@ -519,11 +516,7 @@ var daemon = function(config){
 
         var winsw = require('./winsw'), me = this;
 
-        if (typeof dir === 'function'){
-          callback = dir;
-          dir = null;
-        }
-        dir = this.directory(dir);
+        var dir = this.directory();
 
         // If the output directory does not exist, create it.
         fs.exists(dir,function(exists){

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -255,7 +255,7 @@ var daemon = function(config){
       enumerable: false,
       writable: true,
       configurable: false,
-      value: config.installDir ? path.dirname(config.installDir) : config.script !== null ? config.script : null
+      value: config.installDir ? path.resolve(config.installDir) : config.script !== null ? path.dirname(config.script) : null
     },
 
     /**


### PR DESCRIPTION
This change only affects node-windows. Both node-mac and node-linux have global install locations.

Currently the `install` method of node-windows accepts a parameter named `dir` that will resolve as a path with the daemon folder and it's children appended to it. Currently this results in an error when trying to uninstall the service because the uninstall method does not accept the `dir` parameter, nor does it have any other way of knowing where the daemon folder was installed. 

Furthermore, the exists getter does not detect the service installation because it also has no way of knowing if or what the value of the `dir` parameter that was passed to the `install` method.

```
const scriptPath = path.join(__dirname, 'server', 'dist', 'index.js');

// Create a new service object
const svc = new Service({
  name: `service-name`,
  description: 'Service description',
  script: scriptPath,
  env: [{
    name: 'NODE_ENV',
    value: 'production'
  }]
});

// Listen for the "install" event, which indicates the
// process is available as a service.
svc.on('install',function(){
  console.log('Service installed.');
  svc.start();
  console.log('Service started.');
});

// Listen for the "uninstall" event so we know when it's done.
svc.on('uninstall',function(){
  console.log('Uninstall complete.');
  console.log('The service exists: ', svc.exists);
});

const args = process.argv.slice(2)

switch(args[0]){
  case 'install':
    svc.install(__dirname); // ends up calling this.directory(__dirname)
    console.log(svc.exists) // false - This result is due to the resulting call of this.directory()
    break;
  case 'uninstall':
    svc.uninstall(); // Results in the error "Uninstall was skipped because process does not exist or could not be found." because this.exists === false, despite being able to see the 'daemon' folder in the project root.
    break;
  default:
    console.log('Invalid argument provided.');
    console.log('Valid Arguments:');
    console.log('install');
    console.log('uninstall');
    break;
}
```

This proposed change will remove the `dir` parameter from the `install` method, which is inconsistent with both node-mac and node-linux, while also implementing a more reliable way of being able to specify the desired install directory of the service via a configuration option. This greatly improves the experience for Typescript projects because the script file around which the service will be built will be in a `dist` folder of some kind that is overwritten when building a new version.