### PR TITLE
fix the `isNaN` sanitizer in `kill(..)`.

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -40,7 +40,7 @@ module.exports = {
       throw new Error('PID is required for the kill operation.');
     }
 
-    if (typeof isNaN(pid)) {
+    if (isNaN(pid)) {
       throw new Error('PID must be a number.')
     }
 


### PR DESCRIPTION
The `isNaN(..)` method returns a boolean, therefore the result of the `typeof isNaN(pid)` expression will always be `"boolean"`, therefore the condition in the if-statement is always truthy.  

The result is that all calls to `kill` will throw an `PID must be a number.` exception.  

The fix is simply to remove the `typeof`.