### PR TITLE
Fix typo in author.io/arg requirement

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,6 +1,6 @@
 // Handle input parameters
 var Logger = require('./eventlog'),
-    Args = require('@author.io/args'),
+    Args = require('@author.io/arg'),
     net = require('net'),
     max = 60,
     p = require('path'),


### PR DESCRIPTION
The package name is author.io/arg. This change will solve the following error, which happens every time this module is loaded: "Error: Cannot find module '@author.io/args'"