### PR TITLE
Implement Group Managed Service Account (gMSA) support in node-windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,6 @@ svc.sudo.password = 'password';
 ...
 ```
 
-
-
 **app.js**
 
 To use Group Managed Service Accounts, append `$` to the end of account name and specify `svc.logOnAs.gmsa = true`

--- a/README.md
+++ b/README.md
@@ -245,6 +245,30 @@ svc.sudo.password = 'password';
 ...
 ```
 
+
+
+**app.js**
+
+To use Group Managed Service Accounts, append `$` to the end of account name and specify `svc.logOnAs.gmsa = true`
+
+
+```js
+var Service = require('node-windows').Service;
+
+// Create a new service object
+var svc = new Service({
+  name:'Hello World',
+  script: require('path').join(__dirname,'helloworld.js'),
+  allowServiceLogon: true 
+});
+
+svc.logOnAs.domain = 'mydomain.local';
+svc.logOnAs.account = 'username_$';
+svc.logOnAs.gmsa = true;
+...
+```
+
+
 ### Depending on other services
 
 The service can also be made dependant on other Windows services.

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -402,7 +402,6 @@ var daemon = function (config) {
      *     svc.logOnAs.account = 'username';
      *     svc.logOnAs.password = 'password';
      *     ...
-     * 
      *
      * Both the account and password must be explicitly defined if you want the service to log on as that user,
      * otherwise the Local System account will be used.

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -402,6 +402,7 @@ var daemon = function (config) {
      *     svc.logOnAs.account = 'username';
      *     svc.logOnAs.password = 'password';
      *     ...
+     * 
      *
      * Both the account and password must be explicitly defined if you want the service to log on as that user,
      * otherwise the Local System account will be used.
@@ -410,6 +411,7 @@ var daemon = function (config) {
       enumerable: false,
       writable: true,
       configurable: false,
+      gmsa: false,
       value: {
         account: null,
         password: null,

--- a/lib/winsw.js
+++ b/lib/winsw.js
@@ -125,8 +125,11 @@ console.log({loc: 'winsw.js ~line 77', xml, config})
       var serviceaccount = [
         { domain: config.logOnAs.domain || 'NT AUTHORITY' },
         { user: config.logOnAs.account || 'LocalSystem' },
-        { password: config.logOnAs.password || '' }
       ]
+
+      if(!config.logOnAs.gmsa){
+        serviceaccount.push({ password: config.logOnAs.password || '' })
+      }
 
       if (config.allowServiceLogon) {
         serviceaccount.push({ allowservicelogon: 'true' })


### PR DESCRIPTION
This Pull Request introduces support for Group Managed Service Accounts (gMSA).

To enable Group Managed Service Accounts support, as per the winsw XML configuration file guidelines, the <password> element must be excluded from the configuration.

> ![image](https://github.com/coreybutler/node-windows/assets/16181721/94852fbd-0dce-496d-b88c-fa2ce7c7c25a)
_https://github.com/winsw/winsw/blob/v3/docs/xml-config-file.md#service-account_

**Changes:**

*   Modified `lib/winsw.js` to conditionally add the password to the service account configuration based on `svc.logOnAs.gmsa` property.
* Added `gmsa` property to `logOnAs` object in `lib/daemon.js` to enable gMSA support.
* README.md updated with instructions for gMSA usage.



```
// Example usage

app.js 

var Service = require('node-windows').Service;
var svc = new Service({
  name:'Hello World',
  script: require('path').join(__dirname,'helloworld.js'),
  allowServiceLogon: true 
});
svc.logOnAs.domain = 'mydomain.local';
svc.logOnAs.account = 'username_$';
svc.logOnAs.gmsa = true;
...

```