### PR TITLE
Made id as the configurable field if it is explicitly provided.

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -324,9 +324,10 @@ var daemon = function (config) {
     // The ID for the process
     id: {
       enumerable: true,
-      get: function () {
-        return this.name.replace(/[^\w]/gi, '').toLowerCase();
-      }
+      get: function () {		  
+        return this._id ? this._id : this.name.replace(/[^\w]/gi, '').toLowerCase();
+      },
+      set: function (value) { this._id = value; }    
     },
 
     // Description of the service


### PR DESCRIPTION
Made this change to accommodate the scenario where the Service ID, Name and Description fields are different.