### PR TITLE
Add daemon option to suppress warning logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,17 @@ var log = new EventLogger({
 });
 ```
 
+Warning event logs that are produced by the wrapper can be suppressed by disabling it when creating the service.
+Warning logs are enabled by default.
+
+```js
+var svc = new Service({
+  name:'Hello World',
+  description: 'The nodejs.org example web server.',
+  disableWarningLogs: true,
+});
+```
+
 ---
 
 # Commands

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -106,7 +106,8 @@ var daemon = function (config) {
           '--wait', this.wait,
           '--maxrestarts', this.maxRestarts,
           '--abortonerror', (this.abortOnError == true ? 'y' : 'n'),
-          '--stopparentfirst', this.stopparentfirst
+          '--stopparentfirst', this.stopparentfirst,
+          '--disablewarninglogs', (this.disableWarningLogs==true?'y':'n'),
         ];
 
         if (this.maxRetries !== null) {
@@ -132,7 +133,8 @@ var daemon = function (config) {
           logmode: this.logmode,
           logging: config.logging,
           allowServiceLogon: config.allowServiceLogon,
-          dependsOn: this.dependsOn
+          dependsOn: this.dependsOn,
+          disableWarningLogs: this.disableWarningLogs
         });
       }
     },
@@ -463,6 +465,18 @@ var daemon = function (config) {
       writable: true,
       configurable: false,
       value: config.execPath !== undefined ? require('path').resolve(config.execPath) : null
+    },
+
+    /**
+     * @cfg {Boolean} [disableWarningLogs=false]
+     * Setting this to `true` will prevent warning logs from being sent to the event log.
+     * This is useful if you want to suppress warnings to clear up the event logs.
+     */
+    disableWarningLogs: {
+      enumerable: true,
+      writable: false,
+      configurable: false,
+      value: typeof(config.disableWarningLogs) == 'boolean' ? config.disableWarningLogs : false
     },
 
     /**

--- a/lib/eventlog.js
+++ b/lib/eventlog.js
@@ -182,6 +182,9 @@ var logger = function (config) {
       writable: true,
       configurable: false,
       value: function (message, code, callback) {
+        if (config.disablewarninglogs === 'y') {
+          return;
+        }
         write(this.eventLog, this.source, 'WARNING', message, code, callback);
       }
     },

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -62,8 +62,18 @@ var Logger = require('./eventlog'),
     .check(function (argv) {
       return ['y', 'n', 'yes', 'no'].indexOf(argv.a.trim().toLowerCase()) >= 0;
     })
+    .default('disablewarninglogs','no')
+    .alias('dw','disablewarninglogs')
+    .describe('disablewarninglogs','Prevent warning logs from being written to the event log.')
+    .check(function(argv){
+      return ['y','n','yes','no'].indexOf(argv.a.trim().toLowerCase()) >= 0;
+    })
     .parse(),
-  log = new Logger(argv.e == undefined ? argv.l : { source: argv.l, eventlog: argv.e }),
+  log = new Logger({
+    source: argv.l,
+    ...(argv.e ? {eventlog:argv.e} : {}),
+    disablewarninglogs: argv.dw,
+  }),
   fork = require('child_process').fork,
   script = p.resolve(argv.f),
   wait = argv.w * 1000,


### PR DESCRIPTION
Raised along side this PR - [Prevent security scanner from killing wrapper with ECONNRESET #277
](https://github.com/coreybutler/node-windows/pull/277)

Adds an option `disableWarningLogs` field when creating the daemon service in the install script.  This value is `false` by default (all warning logs will be sent to event log).  When set to `true` no warning logs are sent to the event log.